### PR TITLE
ignoring react/require-default-props for TS function components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### [0.0.4](https://github.com/angellist/eslint-config-angellist/compare/0.0.3...0.0.4) - 2021-04-12
+
+* adds ignoreFunctionalComponents: true for react/require-default-props rule
+
 ### [0.0.3](https://github.com/angellist/eslint-config-angellist/compare/0.0.2...0.0.3) - 2021-04-07
 
 Adds the following changes to eslint rules

--- a/ts.js
+++ b/ts.js
@@ -26,6 +26,7 @@ module.exports = {
     "react/jsx-props-no-spreading": "off",
     "react/no-unescaped-entities": "off",
     "react/prefer-stateless-function": "warn",
+    "react/require-default-props": [2, { ignoreFunctionalComponents: true }],
     "react/static-property-placement": "off",
   },
   plugins: [


### PR DESCRIPTION
The TS compiler will take care of typesafety and you can safely
configure defaults as argument defaults.

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-default-props.md