### PR TITLE
Enable block delimiters in Ruby

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,4 @@ Style/StringLiteralsInInterpolation: { Enabled: true, EnforcedStyle: single_quot
 Style/TrailingCommaInArguments: { Enabled: true, EnforcedStyleForMultiline: consistent_comma } # enable
 Style/TrailingCommaInBlockArgs: { Enabled: true } # enable
 Style/WordArray: { Enabled: false } # disable
+Style/BlockDelimiters: { Enabled: true } # {...} for single-line blocks and do..end for multi-line blocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### [0.1.3](https://github.com/angellist/eslint-config-angellist/compare/0.1.1...0.1.3) - 2023-06-09
+
+* Use {...} for single-line blocks and do..end for multi-line blocks in Ruby
+
 ### [0.1.2](https://github.com/angellist/eslint-config-angellist/compare/0.1.1...0.1.2) - 2022-09-28
 
 * Use Rubocop instead of Prettier Ruby that wraps or merges lines

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sharable ESLint, Prettier and Rubocop configuration for AngelList.
 ```sh
 cd ../frontend-project
 yarn add -D \
-  'git+https://github.com/angellist/eslint-config-angellist#0.1.2' \
+  'git+https://github.com/angellist/eslint-config-angellist#0.1.3' \
   '@typescript-eslint/eslint-plugin' \
   '@typescript-eslint/parser' \
   'eslint-config-airbnb-typescript' \
@@ -39,7 +39,7 @@ module.exports = {
 
 ```sh
 cd ../backend-project
-yarn add -D 'git+https://github.com/angellist/eslint-config-angellist#0.1.2'
+yarn add -D 'git+https://github.com/angellist/eslint-config-angellist#0.1.3'
 ```
 
 Add the following gems to `Gemfile` and then install them with `bundle install`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-angellist",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Sharable ESLint configuration for AngelList",
   "repository": "https://github.com/angellist/eslint-config-angellist",
   "main": "index.js",


### PR DESCRIPTION
Enable rule to use {...} for single-line blocks and do..end for multi-line blocks. We can make this a warning instead of autocorrecting if its to big of a change