### PR TITLE
feat(rubocop): add rule to ban assignments in conditions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,14 +10,14 @@ require:
   - rubocop-thread_safety
   - ./rubocop-cops/sidekiq_dont_use_keyword_arguments.rb
 
-
 # Add Rubocop rules we want to override below, sort them alphabetically
 
+AssignmentInCondition: { Enabled: true, AllowSafeAssignment: false } # `if foo = bar` <- BAD
 Layout/LineLength: { Enabled: true, Severity: warning, AutoCorrect: false } # lower severity, disable autocorrect
 Naming/InclusiveLanguage: { Enabled: false } # disable
 Naming/PredicateName: { Enabled: false } # disable, need to migrate our DB columns to use this one
 Style/DateTime: { Enabled: false } # disable
-Style/MethodCallWithArgsParentheses: { Enabled: false} # disable
+Style/MethodCallWithArgsParentheses: { Enabled: false } # disable
 Style/OpenStructUse: { Enabled: false } # disable
 Style/StringLiterals: { Enabled: true, EnforcedStyle: single_quotes } # use single_quotes
 Style/StringLiteralsInInterpolation: { Enabled: true, EnforcedStyle: single_quotes } # use single_quotes


### PR DESCRIPTION
```rb
if foo = 'bar'   # BAD

if (foo = 'bar') # BAD

foo = 'bar'
if foo           # GOOD
```

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/AssignmentInCondition